### PR TITLE
Fix the package.xml ROS generator to avoid duplicate dependencies

### DIFF
--- a/de.seronet_projekt.xtend.ROS.generator/src/de/seronet_projekt/xtend/ROS/generator/MixedPortROSGenHelpers.xtend
+++ b/de.seronet_projekt.xtend.ROS.generator/src/de/seronet_projekt/xtend/ROS/generator/MixedPortROSGenHelpers.xtend
@@ -42,8 +42,12 @@ import rosInterfacesPool.RosService
 import rosInterfacesPool.RosAction
 import rosInterfacesPool.RosActionClient
 import rosInterfacesPool.RosActionServer
+import java.util.ArrayList
 
 class MixedPortROSGenHelpers {
+	
+	ArrayList<String> unique_dependencies = new ArrayList<String>();
+	
 	def Iterable<MixedPortROS> getAllROSPorts(ComponentDefinition comp) {
 		return comp.elements.filter(MixedPortROS).sortBy[name]
 	}
@@ -75,8 +79,13 @@ class MixedPortROSGenHelpers {
 		return typeString
 	}
 	
-	def Iterable<String> getAllPackageStrings(ComponentDefinition comp) {
-		return comp.allROSPorts.map[it.packageString];
+	def Iterable<String> getAllPackageStrings(ComponentDefinition comp) {		
+   		for (String element:comp.allROSPorts.map[it.packageString]){
+   			if(!unique_dependencies.contains(element)){
+   				unique_dependencies.add(element);
+   				}
+   		}
+		return unique_dependencies;
 	}
 	
 	def Boolean hasActionClients(ComponentDefinition comp) {


### PR DESCRIPTION
cmake command gives the following error if a package dependency is duplicated:

```
e_ROSMixedPort/SeRoNet-Tooling-Infrastructure-master/runtime-EclipseApplication/ComponentRoscob4_3/ROS/src-gen/package.xml':
Error(s):
- The generic dependency on 'sensor_msgs' is redundant with: build_depend, build_export_depend, exec_depend
CMake Error at /opt/ros/kinetic/share/catkin/cmake/safe_execute_process.cmake:11 (message):
  execute_process(/usr/bin/python
  "/opt/ros/kinetic/share/catkin/cmake/parse_package_xml.py"
  "/home/nhg/Desktop/Release_ROSMixedPort/SeRoNet-Tooling-Infrastructure-master/runtime-EclipseApplication/ComponentRoscob4_3/ROS/src-gen/package.xml"
  "/home/nhg/Desktop/Release_ROSMixedPort/SeRoNet-Tooling-Infrastructure-master/runtime-EclipseApplication/ComponentRoscob4_3/smartsoft/build/ROS/catkin_generated/package.cmake")
  returned error code 1
Call Stack (most recent call first):
  /opt/ros/kinetic/share/catkin/cmake/catkin_package_xml.cmake:74 (safe_execute_process)
  /opt/ros/kinetic/share/catkin/cmake/catkin_package_xml.cmake:50 (_catkin_package_xml)
  /opt/ros/kinetic/share/catkin/cmake/catkin_package.cmake:99 (catkin_package_xml)
  /home/nhg/Desktop/Release_ROSMixedPort/SeRoNet-Tooling-Infrastructure-master/runtime-EclipseApplication/ComponentRoscob4_3/ROS/src-gen/CMakeLists.txt:25 (catkin_package)


-- Configuring incomplete, errors occurred!
```
This PR fix the error