### PR TITLE
improve the code generator to minimize the hand written code

### DIFF
--- a/de.seronet_projekt.xtend.ROS.generator/src/de/seronet_projekt/xtend/ROS/generator/ROS_Callbacks.xtend
+++ b/de.seronet_projekt.xtend.ROS.generator/src/de/seronet_projekt/xtend/ROS/generator/ROS_Callbacks.xtend
@@ -149,6 +149,11 @@ class ROS_Callbacks {
 		bool «comp.name»RosPortCallbacks::«srvClient.name»_cb («srvClient.packageString»::«srvClient.messageString»::Request &req, «srvClient.packageString»::«srvClient.messageString»::Response &res)
 		{
 			// for implementing this method, you can use the "COMP->" macro to access the component's class members
+			«FOR activity: comp.elements.filter(Activity)»
+			«FOR link: activity.links.filter(MixedPortROSLink).filter[it.mixedportros == srvClient]»
+			 res= COMP->«activity.name.toFirstLower»->«srvClient.name»_callServiceQuery(req);
+			«ENDFOR»
+			«ENDFOR»
 			return true;
 		}
 		

--- a/de.seronet_projekt.xtend.ROS.generator/src/de/seronet_projekt/xtend/ROS/generator/ext/ROSActivityGeneratorExtension.java
+++ b/de.seronet_projekt.xtend.ROS.generator/src/de/seronet_projekt/xtend/ROS/generator/ext/ROSActivityGeneratorExtension.java
@@ -26,17 +26,17 @@ public class ROSActivityGeneratorExtension implements ActivityGeneratorExtension
 	}
 	
 	@Override
-	public CharSequence getHeaderIncludes(Activity activity) {
-		return impl.getHeaderIncludes(activity);
+	public CharSequence getUserHeaderIncludes(Activity activity) {
+		return impl.getUserHeaderIncludes(activity);
 	}
 
 	@Override
-	public CharSequence getClassMemberPublicDefinition(Activity activity) {
-		return impl.getClassMemberPublicDefinition(activity);
+	public CharSequence getUserClassMemberPublicDefinition(Activity activity) {
+		return impl.getUserClassMemberPublicDefinition(activity);
 	}
 	
 	@Override
-	public CharSequence getSourceImplementation(Activity activity) {
-		return impl.getSourceImplementation(activity);
+	public CharSequence getUserSourceImplementation(Activity activity) {
+		return impl.getUserSourceImplementation(activity);
 	}
 }

--- a/de.seronet_projekt.xtend.ROS.generator/src/de/seronet_projekt/xtend/ROS/generator/ext/ROSActivityGeneratorExtensionImpl.xtend
+++ b/de.seronet_projekt.xtend.ROS.generator/src/de/seronet_projekt/xtend/ROS/generator/ext/ROSActivityGeneratorExtensionImpl.xtend
@@ -7,6 +7,7 @@ import com.google.inject.Inject
 import de.seronet_projekt.xtend.ROS.generator.MixedPortROSGenHelpers
 import org.ecore.component.componentDefinition.ComponentDefinition
 import rosInterfacesPool.RosSubscriber
+import rosInterfacesPool.RosService
 
 class ROSActivityGeneratorExtensionImpl implements ActivityGeneratorExtension {
 	@Inject extension MixedPortROSGenHelpers;
@@ -15,24 +16,32 @@ class ROSActivityGeneratorExtensionImpl implements ActivityGeneratorExtension {
 		"RosActivityGeneratorExtension"
 	}
 	
-	override getHeaderIncludes(Activity activity) 
+	override getUserHeaderIncludes(Activity activity) 
 	'''
 		«FOR link: activity.links.filter(MixedPortROSLink)»
 		#include <«link.mixedportros.packageString»/«link.mixedportros.messageString».h>
 		«ENDFOR»
 	'''
 	
-	override getClassMemberPublicDefinition(Activity activity) 
+	override getUserClassMemberPublicDefinition(Activity activity) 
 	'''
 	«FOR sub: activity.links.filter(MixedPortROSLink).map[mixedportros].filter[it.port instanceof RosSubscriber]»
 	void «sub.name»_cb (const «sub.packageString»::«sub.messageString»::ConstPtr &msg);
 	«ENDFOR»
+	«FOR svrsrv: activity.links.filter(MixedPortROSLink).map[mixedportros].filter[it.port instanceof RosService]»
+	«svrsrv.packageString»::«svrsrv.messageString»::Response «svrsrv.name»_callServiceQuery («svrsrv.packageString»::«svrsrv.messageString»::Request request);
+	«ENDFOR»
 	'''
 	
-	override getSourceImplementation(Activity activity) 
+	override getUserSourceImplementation(Activity activity) 
 	'''
 	«FOR sub: activity.links.filter(MixedPortROSLink).map[mixedportros].filter[it.port instanceof RosSubscriber]»
-	void «activity.name.toFirstUpper»Core::«sub.name»_cb (const «sub.packageString»::«sub.messageString»::ConstPtr &msg) {
+	void «activity.name.toFirstUpper»::«sub.name»_cb (const «sub.packageString»::«sub.messageString»::ConstPtr &msg) {
+		// implement this method
+	}
+	«ENDFOR»
+	«FOR svrsrv: activity.links.filter(MixedPortROSLink).map[mixedportros].filter[it.port instanceof RosService]»
+	«svrsrv.packageString»::«svrsrv.messageString»::Response «activity.name.toFirstUpper»::«svrsrv.name»_callServiceQuery («svrsrv.packageString»::«svrsrv.messageString»::Request request) {
 		// implement this method
 	}
 	«ENDFOR»


### PR DESCRIPTION
For the case of ros subscribers and services servers, the implementation of the callbacks have to be written within the activity and the current implementation of the activity generator extension allows only the include of code on the src-gen folder. This means that the code that the end-user *have to* write manually will be removed automatically by the tooling all the time.

With this fix (together with the improvements here: https://github.com/seronet-project/SeRoNet-Tooling-ROS-Mixed-Port/commit/49ac3b357eaa04a0058a0b517acb4bd099fa8dbd ), we minimize for the ROS-SeRoNet Mixed Port use case the code to be implemented manually and we make the mixed port completely consistent with the Smartsoft and SeRoNet plain ports, where the user can create the models and only has to write the logic of the component on the activity or the answer handler class and not modify the ports definition.

Examples:

- Ros Publisher: instead of: https://github.com/ipa-nhg/SeRoNet-experiments/pull/9/files the user has to implement: https://github.com/ipa-nhg/SeRoNet-experiments/pull/12/files

- Ros Subscriber: instead of: https://github.com/ipa-nhg/SeRoNet-experiments/pull/7/files the user has to implement: https://github.com/ipa-nhg/SeRoNet-experiments/pull/11/files

- Ros Service Client: instead of: https://github.com/ipa-nhg/SeRoNet-experiments/pull/4/files the user has to implement https://github.com/ipa-nhg/SeRoNet-experiments/pull/10/files
